### PR TITLE
Use Python 3.10 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.13'
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- update CI workflow to use Python 3.10

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6856ba1279e4832492728cfa4f7ae9bc