### PR TITLE
Add new unit tests and stopword fallback

### DIFF
--- a/tribeca_insights/tests/test_config.py
+++ b/tribeca_insights/tests/test_config.py
@@ -1,0 +1,45 @@
+import types
+from urllib.error import URLError
+
+import pytest
+
+import tribeca_insights.config as config
+
+
+class FakeRobot:
+    def __init__(self, delays=None, error=False):
+        self.delays = delays or {}
+        self.error = error
+        self.url = None
+
+    def set_url(self, url: str) -> None:
+        self.url = url
+
+    def read(self) -> None:
+        if self.error:
+            raise URLError("fail")
+
+    def crawl_delay(self, ua: str):
+        return self.delays.get(ua)
+
+
+def test_get_crawl_delay_specific(monkeypatch):
+    """Return crawl-delay from robots.txt for our user agent."""
+    robot = FakeRobot({"tribeca-insights": 1.5})
+    monkeypatch.setattr(config.robotparser, "RobotFileParser", lambda: robot)
+    assert config.get_crawl_delay("https://example.com") == pytest.approx(1.5)
+
+
+def test_get_crawl_delay_fallback(monkeypatch):
+    """Fallback to '*' user agent delay when specific not set."""
+    robot = FakeRobot({"*": 0.8})
+    monkeypatch.setattr(config.robotparser, "RobotFileParser", lambda: robot)
+    assert config.get_crawl_delay("https://example.com") == pytest.approx(0.8)
+
+
+def test_get_crawl_delay_error(monkeypatch):
+    """Return default delay when robots.txt cannot be read."""
+    robot = FakeRobot(error=True)
+    monkeypatch.setattr(config.robotparser, "RobotFileParser", lambda: robot)
+    monkeypatch.setattr(config, "crawl_delay", 0.3)
+    assert config.get_crawl_delay("https://example.com") == pytest.approx(0.3)

--- a/tribeca_insights/tests/test_crawler.py
+++ b/tribeca_insights/tests/test_crawler.py
@@ -1,0 +1,62 @@
+import time
+
+from bs4 import BeautifulSoup
+
+import tribeca_insights.crawler as crawler
+
+
+def test_get_external_links():
+    html = '<a href="https://ext.com">ex</a><a href="https://mysite.com">in</a>'
+    soup = BeautifulSoup(html, "html.parser")
+    links = crawler.get_external_links(soup, "mysite.com")
+    assert links == {"https://ext.com"}
+
+
+def test_extract_page_metadata():
+    html = (
+        "<html><head><title>T</title><meta name='description' content='d'></head>"
+        "<body><h1>H1</h1><h2>H2</h2></body></html>"
+    )
+    soup = BeautifulSoup(html, "html.parser")
+    (slug_title, headings, desc) = crawler._extract_page_metadata(
+        soup, "https://mysite.com/path", "mysite.com"
+    )
+    assert slug_title == ("path", "T")
+    assert desc == "d"
+    assert headings == ["# H1", "## H2"]
+
+
+def test_collect_media_and_links():
+    html = (
+        "<img src='img.png' alt='a'><a href='https://ext.com'>e</a>"
+        "<a href='https://mysite.com/page'>in</a>"
+    )
+    soup = BeautifulSoup(html, "html.parser")
+    images, external = crawler._collect_media_and_links(soup, "mysite.com")
+    assert images == [{"src": "img.png", "alt": "a"}]
+    assert external == {"https://ext.com"}
+
+
+def test_fetch_and_process(monkeypatch, tmp_path):
+    html = (
+        "<html><head><title>T</title><meta name='description' content='d'></head>"
+        "<body><h1>H1</h1><p>body</p><a href='https://ext.com'>e</a></body></html>"
+    )
+
+    class FakeResp:
+        def __init__(self, text: str):
+            self.text = text
+
+    monkeypatch.setattr(crawler.session, "get", lambda url, timeout: FakeResp(html))
+    monkeypatch.setattr(crawler, "export_page_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(crawler, "extract_visible_text", lambda t: "Body text")
+    monkeypatch.setattr(crawler, "clean_and_tokenize", lambda t, l: ["body", "text"])
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    vis, ext, index, md, data = crawler.fetch_and_process(
+        "https://mysite.com", "mysite.com", tmp_path, "en", timeout=1
+    )
+    assert vis == "Body text"
+    assert ext == {"https://ext.com"}
+    assert md == "home.md"
+    assert data["title"] == "T"


### PR DESCRIPTION
## Summary
- add pytest coverage for config, storage, and crawler modules
- fallback stopwords when NLTK data missing
- test reconciliations with simple sitemap and markdown files

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c0f5113083248903c7ccd7c58f09