### PR TITLE
Update CLI to reconcile markdown before crawling

### DIFF
--- a/tribeca_insights/cli.py
+++ b/tribeca_insights/cli.py
@@ -12,7 +12,9 @@ import pandas as pd
 from tribeca_insights.config import HTTP_TIMEOUT, SUPPORTED_LANGUAGES
 from tribeca_insights.crawler import crawl_site
 from tribeca_insights.storage import (
+    add_urls_from_sitemap,
     load_visited_urls,
+    reconcile_md_files,
     save_visited_urls,
     setup_project_folder,
 )
@@ -110,6 +112,10 @@ def main() -> None:
                 [{"URL": base_url, "Status": 2, "Data": "", "MD File": ""}]
             )
             save_visited_urls(visited_df, Path.cwd() / f"visited_urls_{slug}.csv")
+
+        visited_df = reconcile_md_files(visited_df, project_folder)
+        visited_df = add_urls_from_sitemap(base_url, visited_df)
+        save_visited_urls(visited_df, Path.cwd() / f"visited_urls_{slug}.csv")
         crawl_site(
             slug,
             base_url,

--- a/tribeca_insights/tests/test_config.py
+++ b/tribeca_insights/tests/test_config.py
@@ -1,4 +1,3 @@
-import types
 from urllib.error import URLError
 
 import pytest

--- a/tribeca_insights/tests/test_crawler.py
+++ b/tribeca_insights/tests/test_crawler.py
@@ -50,7 +50,9 @@ def test_fetch_and_process(monkeypatch, tmp_path):
     monkeypatch.setattr(crawler.session, "get", lambda url, timeout: FakeResp(html))
     monkeypatch.setattr(crawler, "export_page_to_markdown", lambda *a, **k: None)
     monkeypatch.setattr(crawler, "extract_visible_text", lambda t: "Body text")
-    monkeypatch.setattr(crawler, "clean_and_tokenize", lambda t, l: ["body", "text"])
+    monkeypatch.setattr(
+        crawler, "clean_and_tokenize", lambda t, _lang: ["body", "text"]
+    )
     monkeypatch.setattr(time, "sleep", lambda s: None)
 
     vis, ext, index, md, data = crawler.fetch_and_process(

--- a/tribeca_insights/tests/test_storage.py
+++ b/tribeca_insights/tests/test_storage.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pandas as pd
 
 import tribeca_insights.storage as storage

--- a/tribeca_insights/text_utils.py
+++ b/tribeca_insights/text_utils.py
@@ -11,7 +11,7 @@ import logging
 import os
 import re
 from functools import lru_cache
-from typing import Dict, List, Optional, Set
+from typing import List, Optional, Set
 
 import nltk
 


### PR DESCRIPTION
## Summary
- reconcile markdown files and sitemap URLs in CLI before crawling
- ensure linter passes by cleaning imports in tests and text utils

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856cc7b6d408324bdd37a70ac8d0ead