### PR TITLE
Implement project JSON utility

### DIFF
--- a/tribeca_insights/cli.py
+++ b/tribeca_insights/cli.py
@@ -9,8 +9,9 @@ from pathlib import Path
 
 import pandas as pd
 
-from tribeca_insights.config import HTTP_TIMEOUT, SUPPORTED_LANGUAGES
+from tribeca_insights.config import HTTP_TIMEOUT, SUPPORTED_LANGUAGES, crawl_delay
 from tribeca_insights.crawler import crawl_site
+from tribeca_insights.exporters.json import update_project_json
 from tribeca_insights.storage import (
     add_urls_from_sitemap,
     load_visited_urls,
@@ -116,7 +117,7 @@ def main() -> None:
         visited_df = reconcile_md_files(visited_df, project_folder)
         visited_df = add_urls_from_sitemap(base_url, visited_df)
         save_visited_urls(visited_df, Path.cwd() / f"visited_urls_{slug}.csv")
-        crawl_site(
+        _full_text, pages_data = crawl_site(
             slug,
             base_url,
             project_folder,
@@ -125,6 +126,16 @@ def main() -> None:
             cmd_args.workers,
             site_language=language,
             timeout=cmd_args.timeout,
+        )
+        update_project_json(
+            project_folder,
+            slug,
+            base_url,
+            language,
+            pages_data,
+            cmd_args.max_pages,
+            cmd_args.workers,
+            crawl_delay,
         )
     elif args.command == "export":
         from tribeca_insights.exporters import export_data  # implement export_data()

--- a/tribeca_insights/tests/test_project_json.py
+++ b/tribeca_insights/tests/test_project_json.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+from tribeca_insights.exporters.json import update_project_json
+
+
+def test_update_project_json_creates(tmp_path: Path) -> None:
+    slug = "example-com"
+    pages = [{"slug": "home", "title": "Home"}]
+    update_project_json(tmp_path, slug, "https://example.com", "en", pages, 5, 2, 0.0)
+    path = tmp_path / f"project_{slug}.json"
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert data["project_slug"] == slug
+    assert data["pages_count"] == 1
+    assert data["created_at"] == data["last_updated_at"]
+
+
+def test_update_project_json_updates(tmp_path: Path) -> None:
+    slug = "example-com"
+    existing = {
+        "project_slug": slug,
+        "created_at": "2020-01-01T00:00:00",
+        "last_updated_at": "2020-01-01T00:00:00",
+        "pages": [{"slug": "home", "title": "Old"}],
+        "pages_count": 1,
+    }
+    path = tmp_path / f"project_{slug}.json"
+    path.write_text(json.dumps(existing))
+    pages = [
+        {"slug": "home", "title": "New"},
+        {"slug": "about", "title": "About"},
+    ]
+    update_project_json(tmp_path, slug, "https://example.com", "en", pages, 5, 2, 0.0)
+    data = json.loads(path.read_text())
+    assert data["created_at"] == "2020-01-01T00:00:00"
+    assert data["pages_count"] == 2
+    slugs = {p["slug"] for p in data["pages"]}
+    assert {"home", "about"} <= slugs
+    assert data["last_updated_at"] != "2020-01-01T00:00:00"


### PR DESCRIPTION
## Summary
- add `update_project_json` helper to consolidate crawl metadata
- call the helper in CLI after crawling
- test creating and updating project JSON

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d26c88448324b2302a5cf9464dda