### PR TITLE
Add exporter tests and markdown reconciliation integration

### DIFF
--- a/tribeca_insights/tests/test_exporters.py
+++ b/tribeca_insights/tests/test_exporters.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from tribeca_insights.exporters.csv import export_csv
+from tribeca_insights.exporters.json import export_json
+
+
+def test_export_json(tmp_path: Path) -> None:
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    (pages / "a.json").write_text(json.dumps({"slug": "a", "text": "x"}))
+    (pages / "b.json").write_text(json.dumps({"slug": "b", "text": "y"}))
+    out = tmp_path / "combined.json"
+    export_json(str(pages), str(out))
+    data = json.loads(out.read_text())
+    assert {d["slug"] for d in data} == {"a", "b"}
+
+
+def test_export_csv(monkeypatch, tmp_path: Path) -> None:
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    (pages / "p1.json").write_text(json.dumps({"text": "hello world"}))
+    (pages / "p2.json").write_text(json.dumps({"text": "hello data"}))
+
+    def fake_tokenize(text: str, language: str = "english") -> list[str]:
+        return text.split()
+
+    monkeypatch.setattr(
+        "tribeca_insights.exporters.csv.clean_and_tokenize", fake_tokenize
+    )
+    out = tmp_path / "freq.csv"
+    export_csv(str(pages), str(out))
+    csv_path = tmp_path / "keyword_frequency_freq.csv"
+    df = pd.read_csv(csv_path)
+    counts = dict(zip(df.word, df.freq))
+    assert counts["hello"] == 2
+    assert counts["world"] == 1

--- a/tribeca_insights/tests/test_project_json.py
+++ b/tribeca_insights/tests/test_project_json.py
@@ -38,3 +38,13 @@ def test_update_project_json_updates(tmp_path: Path) -> None:
     slugs = {p["slug"] for p in data["pages"]}
     assert {"home", "about"} <= slugs
     assert data["last_updated_at"] != "2020-01-01T00:00:00"
+
+
+def test_update_project_json_fields(tmp_path: Path) -> None:
+    slug = "site"
+    update_project_json(tmp_path, slug, "https://site.com", "en", [], 10, 3, 0.5)
+    data = json.loads((tmp_path / f"project_{slug}.json").read_text())
+    assert data["base_url"] == "https://site.com"
+    assert data["max_pages"] == 10
+    assert data["max_workers"] == 3
+    assert data["crawl_delay"] == 0.5

--- a/tribeca_insights/tests/test_storage.py
+++ b/tribeca_insights/tests/test_storage.py
@@ -52,3 +52,17 @@ def test_reconcile_md_files(tmp_path):
     out = storage.reconcile_md_files(df, folder)
     assert out.loc[0, "MD File"] == "home.md"
     assert out.loc[1, "Status"] == 2
+
+
+def test_reconcile_after_markdown_export(tmp_path):
+    html = "<html><head><title>T</title></head><body>Hi</body></html>"
+    from tribeca_insights.exporters.markdown import export_page_to_markdown
+
+    export_page_to_markdown(
+        tmp_path, "https://example.com/home", html, "example.com", set()
+    )
+    df = pd.DataFrame(
+        [{"URL": "https://example.com/home", "Status": 1, "Data": "", "MD File": ""}]
+    )
+    out = storage.reconcile_md_files(df, tmp_path)
+    assert out.loc[0, "MD File"] == "home.md"


### PR DESCRIPTION
## Summary
- add integration test for markdown reconciliation
- test JSON and CSV export helpers
- extend project JSON update coverage

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d3c54e2883248543e8bfdf4b96e3