### PR TITLE
Implement JSON file reconciliation and index generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,14 @@ Tribeca Insights opera em oito etapas principais:
      - `project_<domain_slug>_template.json` copiado de `docs/examples/project_DOMAIN_template.json`.
      - `pages_md/` para arquivos Markdown.
      - `pages_json/` para JSON de cada página (estrutura igual ao objeto `pages` do JSON do projeto).
+     - `index.md` inicial listando as páginas processadas (atualizado no passo 7).
 3. **Carregamento de histórico**  
-   - Usa `load_visited_urls` para ler `visited_urls_<domain>.csv` e identificar URLs já processadas.  
-   - Chama `reconcile_md_files` para reprocessar páginas sem `.md`.
+   - Usa `load_visited_urls` para ler `visited_urls_<domain>.csv` e identificar URLs já processadas.
+   - Chama `reconcile_md_files` e `reconcile_json_files` para reprocessar páginas sem `.md` ou `.json`.
 
-4. **Reconciliação de Markdown**  
-   - Verifica cada entrada com status “visitado” (1) e campo `MD File` vazio.  
-   - Se o arquivo `.md` existir, preenche o campo; caso contrário, redefine status para 2 (reprocessar).
+4. **Reconciliação de Markdown e JSON**
+   - Verifica cada entrada com status “visitado” (1) e campos `MD File` ou `JSON File` vazios.
+   - Se os arquivos existirem, preenche os campos; caso contrário, redefine status para 2 (reprocessar).
 
 5. **Crawling & Processamento concorrente**  
    - `crawl_site` busca URLs internas, respeitando `robots.txt` e `crawl-delay`.  

--- a/tribeca_insights/cli.py
+++ b/tribeca_insights/cli.py
@@ -15,6 +15,7 @@ from tribeca_insights.exporters.json import export_pages_json, update_project_js
 from tribeca_insights.storage import (
     add_urls_from_sitemap,
     load_visited_urls,
+    reconcile_json_files,
     reconcile_md_files,
     save_visited_urls,
     setup_project_folder,
@@ -110,11 +111,20 @@ def main() -> None:
         if visited_df.empty:
             logger.info(f"Seeding initial URL '{base_url}' for crawl queue")
             visited_df = pd.DataFrame(
-                [{"URL": base_url, "Status": 2, "Data": "", "MD File": ""}]
+                [
+                    {
+                        "URL": base_url,
+                        "Status": 2,
+                        "Data": "",
+                        "MD File": "",
+                        "JSON File": "",
+                    }
+                ]
             )
             save_visited_urls(visited_df, Path.cwd() / f"visited_urls_{slug}.csv")
 
         visited_df = reconcile_md_files(visited_df, project_folder)
+        visited_df = reconcile_json_files(visited_df, project_folder)
         visited_df = add_urls_from_sitemap(base_url, visited_df)
         save_visited_urls(visited_df, Path.cwd() / f"visited_urls_{slug}.csv")
         _full_text, pages_data = crawl_site(

--- a/tribeca_insights/tests/test_cli.py
+++ b/tribeca_insights/tests/test_cli.py
@@ -16,13 +16,14 @@ def test_cli_calls_export_pages_json(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "crawl_site", lambda *a, **k: ("", pages))
     monkeypatch.setattr(cli, "add_urls_from_sitemap", lambda base_url, df: df)
     monkeypatch.setattr(cli, "reconcile_md_files", lambda df, folder: df)
+    monkeypatch.setattr(cli, "reconcile_json_files", lambda df, folder: df)
     monkeypatch.setattr(cli, "save_visited_urls", lambda df, path: None)
     monkeypatch.setattr(cli, "update_project_json", lambda *a, **k: None)
     monkeypatch.setattr(
         cli,
         "load_visited_urls",
         lambda *_args, **_kw: pd.DataFrame(
-            columns=["URL", "Status", "Data", "MD File"]
+            columns=["URL", "Status", "Data", "MD File", "JSON File"]
         ),
     )
 

--- a/tribeca_insights/tests/test_storage.py
+++ b/tribeca_insights/tests/test_storage.py
@@ -6,15 +6,27 @@ import tribeca_insights.storage as storage
 def test_load_visited_urls_empty(tmp_path):
     df = storage.load_visited_urls(tmp_path, "example")
     assert df.empty
-    assert list(df.columns) == ["URL", "Status", "Data", "MD File"]
+    assert list(df.columns) == ["URL", "Status", "Data", "MD File", "JSON File"]
 
 
 def test_save_and_load(tmp_path):
     csv_path = tmp_path / "visited.csv"
     df = pd.DataFrame(
         [
-            {"URL": "http://a", "Status": 1, "Data": "", "MD File": ""},
-            {"URL": "http://a", "Status": 2, "Data": "", "MD File": ""},
+            {
+                "URL": "http://a",
+                "Status": 1,
+                "Data": "",
+                "MD File": "",
+                "JSON File": "",
+            },
+            {
+                "URL": "http://a",
+                "Status": 2,
+                "Data": "",
+                "MD File": "",
+                "JSON File": "",
+            },
         ]
     )
     storage.save_visited_urls(df, csv_path)
@@ -33,7 +45,17 @@ def test_add_urls_from_sitemap(monkeypatch, tmp_path):
         content = xml.encode()
 
     monkeypatch.setattr(storage.session, "get", lambda url, timeout: FakeResp())
-    df = pd.DataFrame([{"URL": "https://example.com", "Status": 2, "Data": ""}])
+    df = pd.DataFrame(
+        [
+            {
+                "URL": "https://example.com",
+                "Status": 2,
+                "Data": "",
+                "MD File": "",
+                "JSON File": "",
+            }
+        ]
+    )
     new_df = storage.add_urls_from_sitemap("https://example.com", df)
     assert "https://example.com/page" in new_df["URL"].values
 
@@ -45,8 +67,20 @@ def test_reconcile_md_files(tmp_path):
     (pages / "home.md").write_text("hi")
     df = pd.DataFrame(
         [
-            {"URL": "https://example.com/home", "Status": 1, "Data": "", "MD File": ""},
-            {"URL": "https://example.com/miss", "Status": 1, "Data": "", "MD File": ""},
+            {
+                "URL": "https://example.com/home",
+                "Status": 1,
+                "Data": "",
+                "MD File": "",
+                "JSON File": "",
+            },
+            {
+                "URL": "https://example.com/miss",
+                "Status": 1,
+                "Data": "",
+                "MD File": "",
+                "JSON File": "",
+            },
         ]
     )
     out = storage.reconcile_md_files(df, folder)
@@ -62,7 +96,43 @@ def test_reconcile_after_markdown_export(tmp_path):
         tmp_path, "https://example.com/home", html, "example.com", set()
     )
     df = pd.DataFrame(
-        [{"URL": "https://example.com/home", "Status": 1, "Data": "", "MD File": ""}]
+        [
+            {
+                "URL": "https://example.com/home",
+                "Status": 1,
+                "Data": "",
+                "MD File": "",
+                "JSON File": "",
+            }
+        ]
     )
     out = storage.reconcile_md_files(df, tmp_path)
     assert out.loc[0, "MD File"] == "home.md"
+
+
+def test_reconcile_json_files(tmp_path):
+    folder = tmp_path
+    pages = folder / "pages_json"
+    pages.mkdir()
+    (pages / "home.json").write_text("{}")
+    df = pd.DataFrame(
+        [
+            {
+                "URL": "https://example.com/home",
+                "Status": 1,
+                "Data": "",
+                "MD File": "",
+                "JSON File": "",
+            },
+            {
+                "URL": "https://example.com/miss",
+                "Status": 1,
+                "Data": "",
+                "MD File": "",
+                "JSON File": "",
+            },
+        ]
+    )
+    out = storage.reconcile_json_files(df, folder)
+    assert out.loc[0, "JSON File"] == "home.json"
+    assert out.loc[1, "Status"] == 2

--- a/tribeca_insights/tests/test_storage_setup.py
+++ b/tribeca_insights/tests/test_storage_setup.py
@@ -10,3 +10,4 @@ def test_setup_project_folder_creates_structure(tmp_path: Path) -> None:
     assert (folder / "pages_json").exists()
     template = folder / f"project_{slug}_template.json"
     assert template.exists(), "Project template JSON not created"
+    assert (folder / "index.md").exists(), "Index markdown not created"


### PR DESCRIPTION
## Summary
- create index.md when initializing project folder
- track markdown and json filenames in visited URLs
- add `reconcile_json_files` and integrate with CLI
- update README steps for JSON reconciliation
- adjust tests for new index and JSON tracking

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d84225248324a6931c6e4cd39616