### PR TITLE
Add rotating file logging

### DIFF
--- a/tribeca_insights/cli.py
+++ b/tribeca_insights/cli.py
@@ -12,6 +12,7 @@ import pandas as pd
 from tribeca_insights.config import HTTP_TIMEOUT, SUPPORTED_LANGUAGES, crawl_delay
 from tribeca_insights.crawler import crawl_site
 from tribeca_insights.exporters.json import export_pages_json, update_project_json
+from tribeca_insights.logging_utils import setup_logging
 from tribeca_insights.storage import (
     add_urls_from_sitemap,
     load_visited_urls,
@@ -98,6 +99,8 @@ def main() -> None:
             level=logging.INFO,
             format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         )
+
+    setup_logging(Path.cwd() / "logs")
 
     setup_environment()
 

--- a/tribeca_insights/logging_utils.py
+++ b/tribeca_insights/logging_utils.py
@@ -1,0 +1,14 @@
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+
+def setup_logging(log_dir: Path) -> None:
+    """Configure rotating file logging under the given directory."""
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "tribeca-insights.log"
+    fmt = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    handler = RotatingFileHandler(log_path, maxBytes=1_000_000, backupCount=3)
+    handler.setFormatter(logging.Formatter(fmt))
+    logging.getLogger().addHandler(handler)
+    return None

--- a/tribeca_insights/tests/test_cli.py
+++ b/tribeca_insights/tests/test_cli.py
@@ -59,3 +59,5 @@ def test_cli_calls_export_pages_json(monkeypatch, tmp_path):
     assert json_file.exists()
     data = json.loads(json_file.read_text())
     assert data["slug"] == "home"
+    log_file = tmp_path / "logs" / "tribeca-insights.log"
+    assert log_file.exists(), "Log file was not created"


### PR DESCRIPTION
## Summary
- add `logging_utils.setup_logging` helper for rotating log files
- call `setup_logging` in CLI before environment setup
- test that log file is created when running CLI

## Testing
- `black --check tribeca_insights/cli.py tribeca_insights/logging_utils.py tribeca_insights/tests/test_cli.py`
- `isort --check-only .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856dac961188324a7f5a827f22396ff