### PR TITLE
Fix exporter logging

### DIFF
--- a/tribeca_insights/exporters/csv.py
+++ b/tribeca_insights/exporters/csv.py
@@ -51,7 +51,7 @@ def update_keyword_frequency(
     try:
         df.to_csv(csv_path, index=False)
         logger.info(f"Exported {len(df)} keyword frequencies to {csv_path}")
-        print(f"[Tribeca Insights] Keyword frequency CSV exported to: {csv_path}")
+        logger.info(f"Keyword frequency CSV exported to: {csv_path}")
     except Exception as e:
         logger.error(f"Failed to write CSV {csv_path}: {e}")
     return None


### PR DESCRIPTION
## Summary
- replace `print()` with `logger.info` in CSV exporter

## Testing
- `black --check tribeca_insights/exporters/csv.py`
- `isort tribeca_insights/exporters/csv.py --check-only`
- `flake8 tribeca_insights/exporters/csv.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e0451b708324990d004d5f878d08