### PR TITLE
Fix merge artifact in CSV exporter

### DIFF
--- a/tribeca_insights/exporters/csv.py
+++ b/tribeca_insights/exporters/csv.py
@@ -53,7 +53,6 @@ def update_keyword_frequency(
         logger.info(f"Exported {len(df)} keyword frequencies to {csv_path}")
         print(f"[Tribeca Insights] Keyword frequency CSV exported to: {csv_path}")
     except OSError as e:
-          main
         logger.error(f"Failed to write CSV {csv_path}: {e}")
     return None
 


### PR DESCRIPTION
## Summary
- clean up stray word introduced by merge in `update_keyword_frequency`

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e3e0298083249536825e35b9b5d5