### PR TITLE
Improve failed NLTK download logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Tribeca Insights opera em oito etapas principais:
 1. **Entrada de parâmetros**
    - O usuário executa `tribeca-insights crawl` informando `--slug`, `--base-url`, `--max-pages` e `--language`.
    - Internamente, o CLI (`tribeca_insights.cli`) valida inputs e configura o ambiente (SSL e recursos NLTK).
+   - Se o download automático das stopwords falhar, o log indicará executar `python -m nltk.downloader stopwords` para instalá-las manualmente.
 
 2. **Configuração de pasta de projeto**
    - Cria uma pasta `<domain_slug>/` (ex: `example-com/`) com:

--- a/tribeca_insights/text_utils.py
+++ b/tribeca_insights/text_utils.py
@@ -66,6 +66,9 @@ def setup_environment() -> None:
         logger.info("NLTK stopwords ensured.")
     except OSError as e:
         logger.warning(f"Failed to download NLTK stopwords: {e}")
+        logger.error(
+            "Please run 'python -m nltk.downloader stopwords' to install them manually."
+        )
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
## Summary
- log an error message in `setup_environment` suggesting manual `nltk` install when stopword download fails
- document the new behaviour in the README

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6857441f99748324afbb3aa4c15e1618