### PR TITLE
Add error message when nltk download fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Tribeca Insights opera em oito etapas principais:
 1. **Entrada de parâmetros**
    - O usuário executa `tribeca-insights crawl` informando `--slug`, `--base-url`, `--max-pages` e `--language`.
    - Internamente, o CLI (`tribeca_insights.cli`) valida inputs e configura o ambiente (SSL e recursos NLTK).
-   - Se o download automático das stopwords falhar, o log indicará executar `python -m nltk.downloader stopwords` para instalá-las manualmente.
+   - Se o download automático das stopwords falhar, um erro no log indicará executar `python -m nltk.downloader stopwords` para instalá-las manualmente.
 
 2. **Configuração de pasta de projeto**
    - Cria uma pasta `<domain_slug>/` (ex: `example-com/`) com:

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -75,7 +75,15 @@ def setup_environment() -> None:
         ssl._create_default_https_context = _create_unverified_https_context
     except AttributeError:
         pass
-    nltk.download("stopwords", quiet=True)
+
+    try:
+        nltk.download("stopwords", quiet=True)
+        logger.info("NLTK stopwords ensured.")
+    except OSError as e:
+        logger.warning(f"Failed to download NLTK stopwords: {e}")
+        logger.error(
+            "Please run 'python -m nltk.downloader stopwords' to install them manually."
+        )
 
 
 # Clean and tokenize text by removing non-letter characters, collapsing spaces and stopwords.


### PR DESCRIPTION
## Summary
- log a manual NLTK install suggestion in `scripts/main.py` when download fails
- clarify README about the error message

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685745a8fd548324989f5c53b7b64c46