### PR TITLE
Add type hints for CLI tests

### DIFF
--- a/tribeca_insights/tests/test_cli.py
+++ b/tribeca_insights/tests/test_cli.py
@@ -23,7 +23,15 @@ def test_cli_calls_export_pages_json(monkeypatch, tmp_path):
         cli,
         "load_visited_urls",
         lambda *_args, **_kw: pd.DataFrame(
-            columns=["URL", "Status", "Data", "MD File", "JSON File"]
+            columns=pd.Index(
+                [
+                    "URL",
+                    "Status",
+                    "Data",
+                    "MD File",
+                    "JSON File",
+                ]
+            )
         ),
     )
 
@@ -83,7 +91,15 @@ def test_cli_playwright_flag(monkeypatch, tmp_path):
         cli,
         "load_visited_urls",
         lambda *_args, **_kw: pd.DataFrame(
-            columns=["URL", "Status", "Data", "MD File", "JSON File"]
+            columns=pd.Index(
+                [
+                    "URL",
+                    "Status",
+                    "Data",
+                    "MD File",
+                    "JSON File",
+                ]
+            )
         ),
     )
     original_setup = cli.setup_project_folder


### PR DESCRIPTION
## Summary
- adjust DataFrame construction in `test_cli.py` to satisfy Pyright
- keep pyright, black, isort and flake8 clean

## Testing
- `pyright`
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68575cb6403483248f4e839810f06d9d