### PR TITLE
Handle Playwright timeouts

### DIFF
--- a/tribeca_insights/crawler.py
+++ b/tribeca_insights/crawler.py
@@ -136,6 +136,9 @@ def fetch_and_process(
         else:
             resp = session.get(url, timeout=timeout)
             html = resp.text
+        if not html:
+            logger.error(f"No HTML returned for {url}")
+            return "", set(), ("", ""), "", {}
         time.sleep(crawl_delay)
         soup = BeautifulSoup(html, "html.parser")
         external_links: Set[str] = set()

--- a/tribeca_insights/tests/test_playwright_crawler.py
+++ b/tribeca_insights/tests/test_playwright_crawler.py
@@ -1,0 +1,65 @@
+import logging
+import sys
+import types
+from pathlib import Path
+
+from tribeca_insights import crawler, playwright_crawler
+
+
+def test_fetch_with_playwright_timeout(monkeypatch, caplog):
+    class DummyTimeoutError(Exception):
+        pass
+
+    class DummyPage:
+        def goto(self, url: str, timeout: int) -> None:
+            raise DummyTimeoutError("timeout")
+
+        def content(self) -> str:
+            return "<html></html>"
+
+    class DummyBrowser:
+        def new_page(self) -> DummyPage:
+            return DummyPage()
+
+        def close(self) -> None:
+            pass
+
+    class DummyPlaywright:
+        def __init__(self) -> None:
+            self.firefox = self
+
+        def launch(self, headless: bool = True) -> DummyBrowser:
+            return DummyBrowser()
+
+    class DummyContext:
+        def __enter__(self) -> DummyPlaywright:
+            return DummyPlaywright()
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            pass
+
+    def fake_sync_playwright() -> DummyContext:
+        return DummyContext()
+
+    fake_module = types.ModuleType("playwright.sync_api")
+    fake_module.sync_playwright = fake_sync_playwright
+    fake_module.Error = DummyTimeoutError
+    fake_module.TimeoutError = DummyTimeoutError
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", fake_module)
+
+    caplog.set_level(logging.ERROR, logger="tribeca_insights.playwright_crawler")
+    html = playwright_crawler.fetch_with_playwright("https://example.com", 1)
+    assert html == ""
+    assert any("Playwright error" in r.message for r in caplog.records)
+
+
+def test_fetch_and_process_empty_html(monkeypatch, tmp_path: Path, caplog):
+    caplog.set_level(logging.ERROR, logger="tribeca_insights.crawler")
+    monkeypatch.setattr(crawler, "export_page_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(crawler.time, "sleep", lambda s: None)
+
+    result = crawler.fetch_and_process(
+        "https://example.com", "example.com", tmp_path, fetch_fn=lambda *_a: ""
+    )
+    assert result == ("", set(), ("", ""), "", {})
+    assert any("No HTML returned" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- protect `fetch_with_playwright` against Playwright failures
- log and skip processing when HTML fetch returns empty
- add regression tests for Playwright timeout handling

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68575e3d8eb08324918e7d1290683835