### PR TITLE
Add success/error tests for Playwright crawler

### DIFF
--- a/tribeca_insights/tests/test_playwright_crawler.py
+++ b/tribeca_insights/tests/test_playwright_crawler.py
@@ -63,3 +63,94 @@ def test_fetch_and_process_empty_html(monkeypatch, tmp_path: Path, caplog):
     )
     assert result == ("", set(), ("", ""), "", {})
     assert any("No HTML returned" in r.message for r in caplog.records)
+
+
+def test_fetch_with_playwright_returns_html(monkeypatch):
+    html = "<html><body>Hello</body></html>"
+
+    class DummyPage:
+        def goto(self, url: str, timeout: int) -> None:
+            self.url = url
+
+        def content(self) -> str:
+            return html
+
+    class DummyBrowser:
+        def new_page(self) -> DummyPage:
+            return DummyPage()
+
+        def close(self) -> None:
+            pass
+
+    class DummyPlaywright:
+        def __init__(self) -> None:
+            self.firefox = self
+
+        def launch(self, headless: bool = True) -> DummyBrowser:
+            return DummyBrowser()
+
+    class DummyContext:
+        def __enter__(self) -> DummyPlaywright:
+            return DummyPlaywright()
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            pass
+
+    def fake_sync_playwright() -> DummyContext:
+        return DummyContext()
+
+    fake_module = types.ModuleType("playwright.sync_api")
+    fake_module.sync_playwright = fake_sync_playwright
+    fake_module.Error = Exception
+    fake_module.TimeoutError = Exception
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", fake_module)
+
+    result = playwright_crawler.fetch_with_playwright("https://example.com", 1)
+    assert result == html
+
+
+def test_fetch_with_playwright_error_logging(monkeypatch, caplog):
+    class DummyError(Exception):
+        pass
+
+    class DummyPage:
+        def goto(self, url: str, timeout: int) -> None:
+            raise DummyError("fail")
+
+        def content(self) -> str:
+            return ""
+
+    class DummyBrowser:
+        def new_page(self) -> DummyPage:
+            return DummyPage()
+
+        def close(self) -> None:
+            pass
+
+    class DummyPlaywright:
+        def __init__(self) -> None:
+            self.firefox = self
+
+        def launch(self, headless: bool = True) -> DummyBrowser:
+            return DummyBrowser()
+
+    class DummyContext:
+        def __enter__(self) -> DummyPlaywright:
+            return DummyPlaywright()
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            pass
+
+    def fake_sync_playwright() -> DummyContext:
+        return DummyContext()
+
+    fake_module = types.ModuleType("playwright.sync_api")
+    fake_module.sync_playwright = fake_sync_playwright
+    fake_module.Error = DummyError
+    fake_module.TimeoutError = DummyError
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", fake_module)
+
+    caplog.set_level(logging.ERROR, logger="tribeca_insights.playwright_crawler")
+    html = playwright_crawler.fetch_with_playwright("https://example.com", 1)
+    assert html == ""
+    assert any("Playwright error" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- expand test suite for `fetch_with_playwright`
- test successful HTML retrieval with mocked Playwright
- test error logging on Playwright exception

## Testing
- `flake8`
- `pytest -q`
- `pytest --cov=tribeca_insights -q`

------
https://chatgpt.com/codex/tasks/task_e_68576886985083248a8cad5ddd6684b8