### PR TITLE
Resolve Playwright docs merge conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Opções:
   URL inicial para rastrear (obrigatória).
 - `--playwright`
   Renderiza páginas com Playwright ([docs/playwright.md](docs/playwright.md)).
+Esta opcao e recomendada para sites que dependem de JavaScript para exibir conteudo.
 
 ### Exemplo
 


### PR DESCRIPTION
## Summary
- keep Playwright option and explain when to use it
- ensure documentation still references Playwright markdown output and JSON metadata

## Testing
- `black .`
- `isort .`
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68576e3692b483249beda8385716c3aa