### PR TITLE
Add Playwright install instructions and dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,12 @@ venv-check: ## Check if virtual environment is activated
 	fi
 
 install: venv-check ## Install Python dependencies and NLTK resources
-	@pip install --upgrade pip
-	@pip install -e .
-	@pip install certifi
-	@python -c "import os, certifi; os.environ.setdefault('SSL_CERT_FILE', certifi.where()); import nltk; nltk.download('stopwords')"
+@pip install --upgrade pip
+@pip install -e .
+@pip install certifi
+@pip install playwright
+@playwright install
+@python -c "import os, certifi; os.environ.setdefault('SSL_CERT_FILE', certifi.where()); import nltk; nltk.download('stopwords')"
 
 init: install ## Bootstrap project (recommended before first run)
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Tribeca Insights é uma ferramenta modular de análise SEO e extração semânti
    ```bash
    make init
    ```
+   O comando instala automaticamente o Playwright e os navegadores necessários.
 
 ## Automação
 

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -11,6 +11,8 @@ pip install playwright
 playwright install
 ```
 
+Running `make init` installs Playwright and downloads the browser binaries automatically.
+
 Run `playwright install` once to download the required browser binaries.
 
 ## When It Runs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dev = [
   "black>=23.9",
   "isort>=5.0"
 ]
+playwright = [
+  "playwright>=1.40"
+]
 
 [project.entry-points.console_scripts]
 tribeca-insights = "tribeca_insights.cli:main"

--- a/tribeca_insights/playwright_crawler.py
+++ b/tribeca_insights/playwright_crawler.py
@@ -17,11 +17,15 @@ def fetch_with_playwright(url: str, timeout: int) -> str:
         The page HTML after rendering dynamic content, or an empty string on
         failure.
     """
-    from playwright.sync_api import Error as PlaywrightError
-    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
-    from playwright.sync_api import (
-        sync_playwright,
-    )
+    try:
+        from playwright.sync_api import Error as PlaywrightError
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+        from playwright.sync_api import sync_playwright
+    except ModuleNotFoundError:  # pragma: no cover - environment issue
+        logger.error(
+            "Playwright is required. Run 'pip install playwright' and 'playwright install'."
+        )
+        return ""
 
     html: Optional[str] = None
     with sync_playwright() as p:


### PR DESCRIPTION
## Summary
- add optional dependency for Playwright
- install Playwright via Makefile
- provide helpful ModuleNotFoundError message
- document automatic Playwright install with `make init`

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857712645f883249e323a480d7eeb3f