### PR TITLE
Include Playwright in setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,12 @@ venv-check: ## Check if virtual environment is activated
 	fi
 
 install: venv-check ## Install Python dependencies and NLTK resources
-	@pip install --upgrade pip
-	@pip install -e .
-	@pip install certifi
-	@python -c "import os, certifi; os.environ.setdefault('SSL_CERT_FILE', certifi.where()); import nltk; nltk.download('stopwords')"
+@pip install --upgrade pip
+@pip install -e .
+@pip install playwright
+@playwright install
+@pip install certifi
+@python -c "import os, certifi; os.environ.setdefault('SSL_CERT_FILE', certifi.where()); import nltk; nltk.download('stopwords')"
 
 init: install ## Bootstrap project (recommended before first run)
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Tribeca Insights é uma ferramenta modular de análise SEO e extração semânti
    ```bash
    make init
    ```
+   Esse comando instala todas as dependências do projeto e o Playwright
+   (incluindo os navegadores necessários) de forma automática.
 
 ## Automação
 
@@ -44,6 +46,7 @@ O alvo `make run` executa um crawl de demonstração no domínio
 `tribecadigital.com.br`, rastreando até 20 páginas em inglês. Isso garante:
 - Criação e ativação do ambiente virtual (recomendado)
 - Instalação das dependências
+- Instalação automática do Playwright (navegadores incluídos)
 - Execução de testes
 - Execução de uma varredura padrão
 

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -4,7 +4,8 @@ This project can optionally render pages using Playwright for sites that rely he
 
 ## Installation
 
-Install the package and browser drivers:
+`make init` installs both the Playwright package and browser drivers automatically.
+If you prefer manual setup, run:
 
 ```bash
 pip install playwright

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dev = [
   "black>=23.9",
   "isort>=5.0"
 ]
+playwright = [
+  "playwright>=1.38"
+]
 
 [project.entry-points.console_scripts]
 tribeca-insights = "tribeca_insights.cli:main"

--- a/tribeca_insights/playwright_crawler.py
+++ b/tribeca_insights/playwright_crawler.py
@@ -17,11 +17,15 @@ def fetch_with_playwright(url: str, timeout: int) -> str:
         The page HTML after rendering dynamic content, or an empty string on
         failure.
     """
-    from playwright.sync_api import Error as PlaywrightError
-    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
-    from playwright.sync_api import (
-        sync_playwright,
-    )
+    try:
+        from playwright.sync_api import Error as PlaywrightError
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+        from playwright.sync_api import sync_playwright
+    except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+        logger.error(
+            "Playwright not installed. Run 'pip install playwright' and 'playwright install'."
+        )
+        raise exc
 
     html: Optional[str] = None
     with sync_playwright() as p:


### PR DESCRIPTION
## Summary
- add Playwright optional dependency
- auto-install Playwright in `make init`
- clarify Playwright install steps in docs
- warn when Playwright is missing

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857717fdd548324aa4905303441cf39